### PR TITLE
Allow users to specify their own notification model

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+Not released yet
+----------------
+
+* Add support for custom Notification model specification.
+
 0.5.5 (2023-01-03)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean-build: ## remove build artifacts
 	rm -fr dist/
 	rm -fr .eggs/
 	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . -name '*.egg' -exec rm -fr {} +
 
 clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,3 +45,7 @@ You can configure the library in Django settings. Following options are availabl
 * ``PYNOTIFY_TEMPLATE_TRANSLATE`` (default: ``False``)
 
     Boolean indicating if template string should be translated via ``gettext()`` before rendering.
+
+* ``PYNOTIFY_NOTIFICATION_MODEL`` (default: ``pynotify.Notification``)
+
+    String specifying a custom Notification model in '<app>.<model>' format. Currently, only proxy models are supported.

--- a/example/tests/test_models.py
+++ b/example/tests/test_models.py
@@ -1,17 +1,16 @@
 import datetime
-import pytz
 from decimal import Decimal
 
+import pytz
+from chamber.exceptions import PersistenceException
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
-from django.utils.translation import override, gettext_noop
-from chamber.exceptions import PersistenceException
-
-from pynotify.exceptions import MissingContextVariableError
-from pynotify.helpers import DeletedRelatedObject, SecureRelatedObject
-from pynotify.models import AdminNotificationTemplate, Notification, NotificationTemplate, TEMPLATE_FIELDS
+from django.utils.translation import gettext_noop, override
 
 from articles.models import Article
+from pynotify.exceptions import MissingContextVariableError
+from pynotify.helpers import DeletedRelatedObject, SecureRelatedObject
+from pynotify.models import TEMPLATE_FIELDS, AdminNotificationTemplate, Notification, NotificationTemplate
 
 
 class AdminNotificationTemplateTestCase(TestCase):

--- a/pynotify/config.py
+++ b/pynotify/config.py
@@ -3,13 +3,14 @@ from django.conf import settings as django_settings
 
 class Settings:
     """
-    Holds default configuration values, the values can be overriden in settings with ``PYNOTIFY_`` prefix.
+    Holds default configuration values, the values can be overridden in settings with ``PYNOTIFY_`` prefix.
     """
     PREFIX = 'PYNOTIFY'
     DEFAULTS = {
         'AUTOLOAD_MODULES': None,
         'CELERY_TASK': 'pynotify.tasks.notification_task',
         'ENABLED': True,
+        'NOTIFICATION_MODEL': 'pynotify.Notification',
         'RECEIVER': 'pynotify.receivers.SynchronousReceiver',
         'RELATED_OBJECTS_ALLOWED_ATTRIBUTES': {'get_absolute_url', },
         'STRIP_HTML': False,

--- a/pynotify/handlers.py
+++ b/pynotify/handlers.py
@@ -3,8 +3,8 @@ from collections.abc import Iterable
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
 
-from .helpers import register
-from .models import AdminNotificationTemplate, Notification, NotificationTemplate
+from .helpers import get_notification_model, register
+from .models import AdminNotificationTemplate, NotificationTemplate
 
 
 class HandlerMeta(type):
@@ -102,7 +102,7 @@ class BaseHandler(metaclass=HandlerMeta):
         Creates notification for ``recipient``.
         """
         if self._can_create_notification(recipient):
-            return Notification.objects.create(
+            return get_notification_model().objects.create(
                 recipient=recipient,
                 template=self._template,
                 related_objects=self.get_related_objects(),


### PR DESCRIPTION
This PR adds a setting for users of `pynotify` library to specify their own awesome model for notifications.

Setting 'PYNOTIFY_NOTIFICATION_MODEL' will propagete the set model into all usage of Notification model.

Caution: The exported model should be compatible (have similar attributes) with pynotify.models.Notification.